### PR TITLE
feat: verify message hash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,6 +60,8 @@ dependencies = [
  "alloy-rpc-client",
  "alloy-rpc-types",
  "alloy-serde 0.3.1",
+ "alloy-signer",
+ "alloy-signer-local",
  "alloy-transport",
  "alloy-transport-http",
 ]
@@ -454,6 +456,22 @@ dependencies = [
  "auto_impl",
  "elliptic-curve",
  "k256",
+ "thiserror",
+]
+
+[[package]]
+name = "alloy-signer-local"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fabe917ab1778e760b4701628d1cae8e028ee9d52ac6307de4e1e9286ab6b5f"
+dependencies = [
+ "alloy-consensus",
+ "alloy-network",
+ "alloy-primitives 0.8.0",
+ "alloy-signer",
+ "async-trait",
+ "k256",
+ "rand",
  "thiserror",
 ]
 
@@ -1121,8 +1139,6 @@ dependencies = [
  "alloy",
  "alloy-node-bindings",
  "alloy-primitives 0.8.0",
- "k256",
- "rand",
  "regex",
  "serde_json",
  "tokio",
@@ -1584,7 +1600,6 @@ dependencies = [
  "elliptic-curve",
  "once_cell",
  "sha2",
- "signature",
 ]
 
 [[package]]
@@ -1842,6 +1857,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "parking_lot"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "parking_lot_core"
 version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2076,9 +2101,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.4"
+version = "1.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c117dbdfde9c8308975b6a18d71f3f385c89461f7b3fb054288ecf2a2058ba4c"
+checksum = "4219d74c6b67a3654a9fbebc4b419e22126d13d2f3c4a07ee0cb61ff79a79619"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2088,9 +2113,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b83b8b9847f9bf95ef68afb0b8e6cdb80f498442f5179a29fad448fcc1eaea"
+checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2624,6 +2649,8 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
+ "num_cpus",
+ "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,11 +8,10 @@ license = "MIT OR Apache-2.0"
 alloy = { version = "0.3", features = ["contract", "rpc-types"] }
 
 [dev-dependencies]
+alloy = { version = "0.3", features = ["signer-local"] }
 alloy-node-bindings = { git = "https://github.com/alloy-rs/alloy.git", rev = "d68a6b7" }
-k256 = "0.13"
-rand = "0.8"
 regex = "1"
-tokio = { version = "1", features = ["test-util", "macros", "process"] }
+tokio = { version = "1", features = ["full"] }
 
 [build-dependencies]
 alloy-primitives = { version = "0.8.0" }

--- a/README.md
+++ b/README.md
@@ -23,13 +23,10 @@ erc6492 = { git = "https://github.com/reown-com/erc6492.git", version = "0.1.0" 
 This crate uses [Alloy](https://github.com/alloy-rs) and requires an RPC provider in order to verify all signature types.
 
 ```rust
-use alloy_primitives::{address, bytes, eip191_hash_message};
-use alloy_provider::{network::Ethereum, ReqwestProvider};
-
 let address = address!("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA");
-let message = "xxx";
+let message = eip191_hash_message("Hello, world!");
 let signature = bytes!("aaaa");
-let provider = ReqwestProvider::<Ethereum>::new_http("https://rpc.example.com");
+let provider = ReqwestProvider::<Ethereum>::new_http("https://rpc.example.com".parse().unwrap());
 
 let verification = verify_signature(signature, address, message, provider).await.unwrap();
 if verification.is_valid() {
@@ -37,4 +34,4 @@ if verification.is_valid() {
 }
 ```
 
-See test cases in `src/lib.rs` for more examples.
+See doctest on `verify_signature()` and test cases in `src/lib.rs` for more examples.


### PR DESCRIPTION
Refactors the API to accept any message hash, vs before the message would be eip191 hashed inside `verify_signature()`

Also refactors tests to remove `k256` dependency, improve docs.